### PR TITLE
Add UV project setup for easy installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+venv/
+.venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Project specific
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -10,9 +10,30 @@ You will then implement extensions to improve on top of this baseline.
 
 ## Setup instructions
 
+### Option 1: Using UV (Recommended)
+
+[UV](https://github.com/astral-sh/uv) is a fast Python package installer and resolver. To set up the project with UV:
+
+```bash
+# Install UV if you haven't already
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create a virtual environment and install dependencies
+uv venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install the project and its dependencies
+uv pip install -e .
+```
+
+### Option 2: Using Conda
+
 * Follow `setup.sh` to properly setup a conda environment and install dependencies.
+
+### Additional Notes
+
 * There is a detailed description of the code structure in [STRUCTURE.md](./STRUCTURE.md), including a description of which parts you will need to implement.
-* You are only allowed to use libraries that are installed by `setup.sh`, external libraries that give you other pre-trained models or embeddings are not allowed (e.g., `transformers`).
+* You are only allowed to use libraries that are installed by `setup.sh` or defined in `pyproject.toml`, external libraries that give you other pre-trained models or embeddings are not allowed (e.g., `transformers`).
 
 ## Handout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[project]
+name = "minbert-cs224n"
+version = "0.1.0"
+description = "CS 224N Default Final Project - Multitask BERT Implementation"
+readme = "README.md"
+requires-python = ">=3.8,<3.12"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "Stanford CS 224N"}
+]
+
+dependencies = [
+    "torch>=1.8.0,<2.0.0",
+    "torchvision>=0.9.0",
+    "torchaudio>=0.8.0",
+    "tqdm==4.58.0",
+    "requests==2.25.1",
+    "importlib-metadata==3.7.0",
+    "filelock==3.0.12",
+    "scikit-learn>=0.24.0",
+    "tokenizers==0.10.1",
+    "explainaboard-client==0.0.7",
+    "numpy>=1.19.0,<1.24.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "black>=22.0.0",
+    "flake8>=4.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = [
+    "base_bert",
+    "bert",
+    "classifier",
+    "config",
+    "datasets",
+    "evaluation",
+    "multitask_classifier",
+    "optimizer",
+    "optimizer_test",
+    "prepare_submit",
+    "sanity_check",
+    "tokenizer",
+    "utils"
+]
+
+[tool.setuptools.package-data]
+"*" = ["*.data", "*.npy"]


### PR DESCRIPTION
- Add pyproject.toml with project metadata and dependencies
- Update README.md with UV installation instructions
- Add .gitignore for Python artifacts and virtual environments
- Maintain backward compatibility with existing conda setup

The project can now be installed using:
  uv venv && source .venv/bin/activate && uv pip install -e .